### PR TITLE
build: prepare Peragus for NPM publishing

### DIFF
--- a/srcbook/README.md
+++ b/srcbook/README.md
@@ -1,7 +1,6 @@
-![Srcbook banner light](https://imagedelivery.net/oEu9i3VEvGGhcGGAYXSBLQ/064ebb1f-5153-4581-badd-42b42272fc00/public)
+![Peragus banner](image-23.jpg)
 
 <p align="center">
-  <a href="https://badge.fury.io/js/srcbook"><img src="https://badge.fury.io/js/srcbook.svg" alt="npm version" /></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="Apache 2.0 license" /></a>
 </p>
 
@@ -11,100 +10,132 @@
   <a href="https://www.youtube.com/@srcbook">Youtube</a>
 </p>
 
-## Srcbook
+## Peragus
 
-Srcbook is a TypeScript-centric app development platform. It allows you to create and iterate on web apps incredibly fast using AI as a pair-programmer.
-It can create or edit web apps, and also write and execute backend code through an interactive notebook interface.
+Peragus is an AI-enhanced TypeScript notebook platform designed for productive development with AI assistance.
 
-Srcbook is open-source (apache2) and runs locally on your machine. You need to bring your own API key for AI usage (we strongly recommend Anthropic with `claude-3-5-sonnet-latest`).
+Peragus is open-source (apache2) and runs locally on your machine. You'll need to bring your own API key for AI usage (we strongly recommend Anthropic with `claude-3-5-sonnet-latest`).
 
 ## Features
-
-### App Builder
-
-- AI app builder for TypeScript
-- Create, edit and run web apps
-- Use AI to generate the boilerplate, modify the code, and fix things
-- Edit the app with a hot-reloading web preview
-
-![example app builder app light](https://i.imgur.com/k4xAyCQ.png)
 
 ### Notebooks
 
 - Create, run, and share TypeScript notebooks
 - Export to valid markdown format (.src.md)
-- AI features for exploring and iterating on ideas
+- Advanced AI assistance for exploring and iterating on ideas
+- Intelligent code completion and suggestions
+- Integrated debugging and testing capabilities
 - Diagraming with [mermaid](https://mermaid.js.org) for rich annotations
 - Local execution with a web interface
-- Powered by Node.js
+- Powered by Node.js with TypeScript optimizations
 
-![example notebook light](https://imagedelivery.net/oEu9i3VEvGGhcGGAYXSBLQ/ebfa2bfe-f805-4398-a348-0f48d4f93400/public)
+![example notebook](image-23.jpg)
 
 ## FAQ
 
-See [FAQ](https://github.com/srcbookdev/srcbook/blob/main/FAQ.md).
+See our [GitHub repository](https://github.com/peragus-dev/peragus-app) for frequently asked questions.
 
 ## Getting Started
 
-Srcbook runs locally on your machine as a CLI application with a web interface.
+Peragus runs locally on your machine as a CLI application with a web interface.
 
 ### Requirements
 
-- Node.js v18+
-- We recommend using [nvm](https://github.com/nvm-sh/nvm) to manage local node versions
+- Node 18+, we recommend using [nvm](https://github.com/nvm-sh/nvm) to manage local node versions
+- [corepack](https://nodejs.org/api/corepack.html) to manage package manager versions
 
-### Installing
+### Installation
 
-We recommend using npx to always run the latest version from npm
+We recommend using npx to always run the latest version from npm:
 
 ```bash
 # Using npm
-npx srcbook@latest start
+npx peragus@latest start
 
-# Using your pm equivalent
-pnpm dlx srcbook@latest start
+# Using your package manager equivalent
+pnpm dlx peragus@latest start
 ```
 
-> You can instead use a global install with `<pkg manager> i -g srcbook`
-> and then directly call srcbook with `srcbook start`
-
-Here is the current list of commands:
+You can also install Peragus globally:
 
 ```bash
-$ srcbook -h
-Usage: srcbook [options] [command]
+# Using npm
+npm install -g peragus
 
-Srcbook is a interactive programming environment for TypeScript
+# Then run it using
+peragus start
+```
+
+### MCP Server Integration
+
+Peragus can also be used as an MCP (Model Context Protocol) server, allowing AI models to access and manipulate TypeScript notebooks:
+
+```json
+"peragus-mcp-server": {
+  "command": "node",
+  "args": ["/path/to/node_modules/peragus/dist/src/mcp-server/cli.js"],
+  "env": {}
+}
+```
+
+For more details, check our [GitHub repository](https://github.com/peragus-dev/peragus-app).
+
+### Docker Support
+
+You can also run Peragus using Docker:
+
+```bash
+# Build the Docker image
+docker build -t peragus .
+
+# Run the container
+# The -p flag maps port 2150 from the container to your host machine
+# First -v flag mounts your local .peragus directory to persist data
+# Second -v flag shares your npm cache for better performance
+docker run -p 2150:2150 -v ~/.peragus:/root/.peragus -v ~/.npm:/root/.npm peragus
+```
+
+Make sure to set up your API key after starting the container. You can do this through the web interface at `http://localhost:2150`.
+
+### Commands
+
+```bash
+$ peragus -h
+Usage: peragus [options] [command]
+
+Peragus is an interactive programming environment for TypeScript with AI assistance
 
 Options:
   -V, --version                 output the version number
   -h, --help                    display help for command
 
 Commands:
-  start [options]               Start the Srcbook server
-  import [options] <specifier>  Import a Srcbook
+  start [options]               Start the Peragus server
+  import [options] <specifier>  Import a Notebook
   help [command]                display help for command
 ```
 
 ### Uninstalling
 
-You can remove srcbook by first removing the package, and then cleaning it's local directory on disk:
+You can remove Peragus by first removing the package, and then cleaning its local directory on disk:
 
 ```bash
-rm -rf ~/.srcbook
+rm -rf ~/.peragus
 
 # if you configured a global install
-npm uninstall -g srcbook
+npm uninstall -g peragus
 ```
-
-> if you used another pm you will need to use it's specific uninstall command
 
 ## Analytics and tracking
 
-In order to improve Srcbook, we collect some behavioral analytics. We don't collect any Personal Identifiable Information (PII), our goals are simply to improve the application. The code is open source so you don't have to trust us, you can verify! You can find more information in our [privacy policy](https://github.com/srcbookdev/srcbook/blob/main/PRIVACY-POLICY.md).
+In order to improve Peragus, we collect some behavioral analytics. We don't collect any Personal Identifiable Information (PII), our goals are simply to improve the application. The code is open source so you don't have to trust us, you can verify!
 
-If you want to disable tracking, you can run Srcbook with `SRCBOOK_DISABLE_ANALYTICS=true` set in the environment.
+If you want to disable tracking, you can run Peragus with `PERAGUS_DISABLE_ANALYTICS=true` set in the environment.
 
 ## Contributing
 
-For development instructions, see [CONTRIBUTING.md](https://github.com/srcbookdev/srcbook/blob/main/CONTRIBUTING.md).
+For development instructions, see our [GitHub repository](https://github.com/peragus-dev/peragus-app). We welcome contributions!
+
+## Acknowledgments
+
+Peragus is based on [Srcbook](https://github.com/srcbookdev/srcbook), an open-source TypeScript-centric app development platform. We'd like to thank the Srcbook team for their excellent work which provided the foundation for this project.

--- a/srcbook/package.json
+++ b/srcbook/package.json
@@ -1,9 +1,28 @@
 {
-  "name": "srcbook",
-  "version": "0.0.19",
-  "description": "TypeScript notebooks",
+  "name": "peragus",
+  "version": "0.1.0",
+  "description": "AI-enhanced TypeScript notebook platform for productive development",
   "type": "module",
   "bin": "./dist/bin/cli.mjs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/peragus-dev/peragus-app.git"
+  },
+  "homepage": "https://github.com/peragus-dev/peragus-app",
+  "author": "glassBead",
+  "license": "Apache-2.0",
+  "keywords": [
+    "typescript",
+    "notebook",
+    "javascript",
+    "ai",
+    "development",
+    "coding",
+    "programming",
+    "interactive",
+    "mcp",
+    "model-context-protocol"
+  ],
   "scripts": {
     "start": "node ./dist/bin/cli.mjs start",
     "depcheck": "depcheck",
@@ -39,5 +58,13 @@
   },
   "engines": {
     "node": ">=18"
+  },
+  "files": [
+    "dist/**/*",
+    "LICENSE",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/srcbook/src/cli.mts
+++ b/srcbook/src/cli.mts
@@ -42,11 +42,11 @@ function startServer(port: string, callback: () => void) {
 }
 
 export default function program() {
-  const { name, description, version } = getPackageJson();
+  const { name, version } = getPackageJson();
 
   const program = new Command();
 
-  program.name(name).description(description).version(version);
+  program.name(name).description('Peragus is an interactive programming environment for TypeScript with AI assistance').version(version);
 
   program
     .command('start')


### PR DESCRIPTION
- Renamed package from srcbook to peragus
- Updated package metadata (version, description, keywords, etc.)
- Added repository and homepage information
- Updated CLI description to reflect Peragus branding
- Added files array to control which files are published
- Configured public access for NPM publishing
- Updated README with Peragus branding and installation instructions