### PR TITLE
Fix ESLint parser config and small type cleanups

### DIFF
--- a/packages/configs/eslint/library.js
+++ b/packages/configs/eslint/library.js
@@ -4,7 +4,9 @@ const project = resolve(process.cwd(), 'tsconfig.json');
 
 /** @type {import("eslint").Linter.Config} */
 module.exports = {
-  extends: ['prettier', 'turbo'],
+  extends: ['prettier', 'turbo', 'plugin:@typescript-eslint/recommended'],
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint'],
   globals: {
     React: true,
     JSX: true,

--- a/packages/error-recovery/src/types/index.mts
+++ b/packages/error-recovery/src/types/index.mts
@@ -74,7 +74,7 @@ export interface HealthCheckResult {
   timestamp: Date;
   responseTime: number;
   details: string;
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 export interface ServiceHealth {
@@ -157,7 +157,7 @@ export interface DegradationConfig {
   /** Features to disable at this level */
   disabledFeatures: string[];
   /** Fallback implementations */
-  fallbacks: Record<string, () => Promise<any>>;
+  fallbacks: Record<string, () => Promise<unknown>>;
   /** Cache settings for degraded mode */
   cacheSettings: {
     enabled: boolean;
@@ -217,7 +217,7 @@ export interface RecoveryResult {
   action: string;
   duration: number;
   error?: Error;
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 export interface RecoveryPlan {
@@ -294,7 +294,7 @@ export const RetryConfigSchema = z.object({
 export const DegradationConfigSchema = z.object({
   level: z.nativeEnum(DegradationLevel).default(DegradationLevel.NONE),
   disabledFeatures: z.array(z.string()).default([]),
-  fallbacks: z.record(z.any()).default({}),
+  fallbacks: z.record(z.unknown()).default({}),
   cacheSettings: z.object({
     enabled: z.boolean().default(true),
     ttl: z.number().min(1000).max(3600000).default(300000),
@@ -317,7 +317,7 @@ export interface ErrorRecoveryEvent {
         'degradation_deactivated' | 'recovery_plan_executed' | 'service_recovered';
   serviceId: string;
   timestamp: Date;
-  data: Record<string, any>;
+  data: Record<string, unknown>;
   severity: 'low' | 'medium' | 'high' | 'critical';
 }
 

--- a/packages/error-recovery/tsconfig.lint.json
+++ b/packages/error-recovery/tsconfig.lint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*.ts", "src/**/*.mts", "src/tests/**/*.ts", "src/tests/**/*.mts"]
+}

--- a/packages/integration-tests/src/e2e/mcp-workflow-tests.ts
+++ b/packages/integration-tests/src/e2e/mcp-workflow-tests.ts
@@ -23,7 +23,7 @@ export interface TestStep {
   description: string;
   timeout: number;
   action: string;
-  parameters: Record<string, any>;
+  parameters: Record<string, unknown>;
 }
 
 /**

--- a/packages/integration-tests/src/orchestrator/test-orchestrator.ts
+++ b/packages/integration-tests/src/orchestrator/test-orchestrator.ts
@@ -107,9 +107,11 @@ export class TestOrchestratorImpl implements TestOrchestrator {
     };
   }
 
-  async scheduleTest(_scenario: TestScenario, _schedule: CronSchedule): Promise<string> {
+  async scheduleTest(scenario: TestScenario, schedule: CronSchedule): Promise<string> {
+    void scenario;
+    void schedule;
     const scheduleId = this.generateId();
-    
+
     // For now, just return the schedule ID
     // In a real implementation, this would use node-cron
     return scheduleId;

--- a/packages/integration-tests/src/types/test-orchestrator.ts
+++ b/packages/integration-tests/src/types/test-orchestrator.ts
@@ -71,15 +71,15 @@ export interface StepResult {
   step: string;
   success: boolean;
   duration: number;
-  result?: any;
+  result?: unknown;
   error?: string;
 }
 
 export interface AssertionResult {
   assertion: string;
   success: boolean;
-  expected: any;
-  actual: any;
+  expected: unknown;
+  actual: unknown;
   message?: string;
 }
 
@@ -87,7 +87,7 @@ export interface LogEntry {
   timestamp: Date;
   level: LogLevel;
   message: string;
-  context?: Record<string, any>;
+  context?: Record<string, unknown>;
 }
 
 export enum LogLevel {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -27,7 +27,8 @@
     "@modelcontextprotocol/sdk": "^1.12.1",
     "@peragus/api": "workspace:^",
     "@peragus/shared": "workspace:^",
-    "zod": "catalog:"
+    "zod": "catalog:",
+    "express": "^4.18.2"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/security/.eslintrc.cjs
+++ b/packages/security/.eslintrc.cjs
@@ -3,7 +3,7 @@ module.exports = {
   extends: [require.resolve('@peragus/configs/eslint/library.js')],
   parser: '@typescript-eslint/parser',
   parserOptions: {
-    project: './tsconfig.lint.json',
+    project: './tsconfig.json',
     tsconfigRootDir: __dirname,
   },
   globals: {

--- a/packages/security/src/middleware/validation.mts
+++ b/packages/security/src/middleware/validation.mts
@@ -305,18 +305,20 @@ export function createValidationMiddleware(schema: ValidationSchema) {
   return async (req: AuthenticatedRequest, res: Response, next: NextFunction): Promise<void> => {
     try {
       const { body, query, params, headers } = req;
-      let validatedData: Record<string, any> = {};
+      const validatedData: Record<string, unknown> = {};
       const validationErrors: FieldErrorDetail[] = [];
 
       if (schema.body) {
         const result = schema.body.safeParse(body);
         if (!result.success) {
-          const errors: FieldErrorDetail[] = result.error.errors.map((e: z.ZodIssue) => ({
-            field: e.path.join('.'),
-            message: e.message,
-            value: 'input' in e ? (e as any).input : undefined,
-            code: String(e.code)
-          }));
+          const errors: FieldErrorDetail[] = result.error.errors.map(
+            (e: z.ZodIssue & { input?: unknown }) => ({
+              field: e.path.join('.'),
+              message: e.message,
+              value: 'input' in e ? e.input : undefined,
+              code: String(e.code)
+            })
+          );
           validationErrors.push(...errors);
         } else {
           validatedData.body = result.data;
@@ -326,12 +328,14 @@ export function createValidationMiddleware(schema: ValidationSchema) {
       if (schema.query) {
         const result = schema.query.safeParse(query);
         if (!result.success) {
-          const errors: FieldErrorDetail[] = result.error.errors.map((e: z.ZodIssue) => ({
-            field: e.path.join('.'),
-            message: e.message,
-            value: 'input' in e ? (e as any).input : undefined,
-            code: String(e.code)
-          }));
+          const errors: FieldErrorDetail[] = result.error.errors.map(
+            (e: z.ZodIssue & { input?: unknown }) => ({
+              field: e.path.join('.'),
+              message: e.message,
+              value: 'input' in e ? e.input : undefined,
+              code: String(e.code)
+            })
+          );
           validationErrors.push(...errors);
         } else {
           validatedData.query = result.data;
@@ -341,12 +345,14 @@ export function createValidationMiddleware(schema: ValidationSchema) {
       if (schema.params) {
         const result = schema.params.safeParse(params);
         if (!result.success) {
-          const errors: FieldErrorDetail[] = result.error.errors.map((e: z.ZodIssue) => ({
-            field: e.path.join('.'),
-            message: e.message,
-            value: 'input' in e ? (e as any).input : undefined,
-            code: String(e.code)
-          }));
+          const errors: FieldErrorDetail[] = result.error.errors.map(
+            (e: z.ZodIssue & { input?: unknown }) => ({
+              field: e.path.join('.'),
+              message: e.message,
+              value: 'input' in e ? e.input : undefined,
+              code: String(e.code)
+            })
+          );
           validationErrors.push(...errors);
         } else {
           validatedData.params = result.data;
@@ -356,12 +362,14 @@ export function createValidationMiddleware(schema: ValidationSchema) {
       if (schema.headers) {
         const result = schema.headers.safeParse(headers);
         if (!result.success) {
-          const errors: FieldErrorDetail[] = result.error.errors.map((e: z.ZodIssue) => ({
-            field: e.path.join('.'),
-            message: e.message,
-            value: 'input' in e ? (e as any).input : undefined,
-            code: String(e.code)
-          }));
+          const errors: FieldErrorDetail[] = result.error.errors.map(
+            (e: z.ZodIssue & { input?: unknown }) => ({
+              field: e.path.join('.'),
+              message: e.message,
+              value: 'input' in e ? e.input : undefined,
+              code: String(e.code)
+            })
+          );
           validationErrors.push(...errors);
         } else {
           // Be careful with mutating req.headers, usually not recommended
@@ -390,7 +398,7 @@ export function createValidationMiddleware(schema: ValidationSchema) {
       }
 
       // Attach validated data to request for downstream handlers
-      (req as any).validatedData = validatedData;
+      req.validatedData = validatedData;
 
       next();
     } catch (error) {

--- a/packages/security/src/types/security.mts
+++ b/packages/security/src/types/security.mts
@@ -104,6 +104,7 @@ export interface AuthenticatedRequest extends Request {
   token?: JWTPayload;
   sessionID: string;  // Made required
   sessionId?: string; // Keep this for backward compatibility
+  validatedData?: Record<string, unknown>;
 }
 
 export interface SecurityContext {
@@ -150,8 +151,8 @@ export interface SecurityEvent {
   resource: string;
   action: string;
   outcome: 'success' | 'failure' | 'blocked';
-  details: Record<string, any>;
-  metadata?: Record<string, any>;
+  details: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
 }
 
 export const SecurityEventType = {

--- a/packages/shared/src/types/feedback.mts
+++ b/packages/shared/src/types/feedback.mts
@@ -1,4 +1,4 @@
-export type AppGenerationFeedbackType = {
+export interface AppGenerationFeedbackType {
   planId: string;
-  feedback: any;
-};
+  feedback: unknown;
+}

--- a/packages/shared/src/utils.mts
+++ b/packages/shared/src/utils.mts
@@ -75,7 +75,7 @@ export function getDefaultExtensionForLanguage(language: CodeLanguageType) {
  * @returns An AsyncIterable over the stream contents.
  */
 export function StreamToIterable<T>(stream: ReadableStream<T>): AsyncIterable<T> {
-  // @ts-ignore
+  // @ts-expect-error -- older Node types may not define Symbol.asyncIterator on ReadableStream
   return stream[Symbol.asyncIterator] ? stream[Symbol.asyncIterator]() : createIterable(stream);
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -412,6 +412,9 @@ importers:
       '@peragus/shared':
         specifier: workspace:^
         version: link:../shared
+      express:
+        specifier: ^4.18.2
+        version: 4.20.0
       zod:
         specifier: 'catalog:'
         version: 3.23.8


### PR DESCRIPTION
## Summary
- enable TypeScript lint rules in base ESLint config
- add express dependency for MCP server
- add ESLint config for security package
- provide lint tsconfig for error recovery package
- use `unknown` instead of `any` in several places
- expose validated data on request

## Testing
- `pnpm lint` *(fails: @peragus/mcp-client#lint)*
- `pnpm test` *(fails: @peragus/mcp-server#test)*

------
https://chatgpt.com/codex/tasks/task_e_6855ad107eac8325a88d9d2b0f2de393